### PR TITLE
Move the `FakeLLM` in `tests/unit_tests` from there to `llms`, and

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,16 @@
 autodoc_pydantic==1.8.0
+duckdb-engine
+freezegun
 myst_parser
 nbsphinx==0.8.9
+responses
 sphinx==4.5.0
 sphinx-autobuild==2021.3.14
 sphinx_book_theme
 sphinx_rtd_theme==1.0.0
 sphinx-typlog-theme==0.8.0
 sphinx-panels
+tenacity
 toml
 myst_nb
+numpy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 autodoc_pydantic==1.8.0
+dataclasses_json
 duckdb-engine
 freezegun
 myst_parser

--- a/langchain/llms/fake_llm.py
+++ b/langchain/llms/fake_llm.py
@@ -10,6 +10,7 @@ class FakeLLM(LLM, BaseModel):
     """Fake LLM wrapper for testing purposes."""
 
     queries: Optional[Mapping] = None
+    n: int = 1
 
     @property
     def _llm_type(self) -> str:

--- a/langchain/llms/fake_llm.py
+++ b/langchain/llms/fake_llm.py
@@ -21,7 +21,7 @@ class FakeLLM(LLM, BaseModel):
         """First try to lookup in queries, else return 'foo' or 'bar'."""
         if self.queries is not None:
             return self.queries[prompt]
-        if stop is None:
+        if stop is None or len(prompt) > 10000:
             return "foo"
         else:
             return "bar"

--- a/tests/integration_tests/chains/test_memory.py
+++ b/tests/integration_tests/chains/test_memory.py
@@ -1,6 +1,6 @@
 """Test memory functionality."""
 from langchain.chains.conversation.memory import ConversationSummaryBufferMemory
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 def test_summary_buffer_memory_no_buffer_yet() -> None:

--- a/tests/unit_tests/agents/test_mrkl.py
+++ b/tests/unit_tests/agents/test_mrkl.py
@@ -6,7 +6,7 @@ from langchain.agents.mrkl.base import ZeroShotAgent, get_action_and_input
 from langchain.agents.mrkl.prompt import FORMAT_INSTRUCTIONS, PREFIX, SUFFIX
 from langchain.agents.tools import Tool
 from langchain.prompts import PromptTemplate
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 def test_get_action_and_input() -> None:

--- a/tests/unit_tests/chains/test_api.py
+++ b/tests/unit_tests/chains/test_api.py
@@ -8,7 +8,7 @@ from langchain import LLMChain
 from langchain.chains.api.base import APIChain
 from langchain.chains.api.prompt import API_RESPONSE_PROMPT, API_URL_PROMPT
 from langchain.requests import RequestsWrapper
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 class FakeRequestsChain(RequestsWrapper):

--- a/tests/unit_tests/chains/test_conversation.py
+++ b/tests/unit_tests/chains/test_conversation.py
@@ -9,7 +9,7 @@ from langchain.chains.conversation.memory import (
     ConversationSummaryMemory,
 )
 from langchain.prompts.prompt import PromptTemplate
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 def test_memory_ai_prefix() -> None:

--- a/tests/unit_tests/chains/test_hyde.py
+++ b/tests/unit_tests/chains/test_hyde.py
@@ -11,6 +11,7 @@ from langchain.llms.base import BaseLLM
 from langchain.llms.fake_llm import FakeLLM
 from langchain.schema import Generation, LLMResult
 
+
 class FakeEmbeddings(Embeddings):
     """Fake embedding class for tests."""
 

--- a/tests/unit_tests/chains/test_hyde.py
+++ b/tests/unit_tests/chains/test_hyde.py
@@ -8,8 +8,8 @@ from langchain.chains.hyde.base import HypotheticalDocumentEmbedder
 from langchain.chains.hyde.prompts import PROMPT_MAP
 from langchain.embeddings.base import Embeddings
 from langchain.llms.base import BaseLLM
+from langchain.llms.fake_llm import FakeLLM
 from langchain.schema import Generation, LLMResult
-
 
 class FakeEmbeddings(Embeddings):
     """Fake embedding class for tests."""
@@ -21,22 +21,6 @@ class FakeEmbeddings(Embeddings):
     def embed_query(self, text: str) -> List[float]:
         """Return random floats."""
         return list(np.random.uniform(0, 1, 10))
-
-
-class FakeLLM(BaseLLM, BaseModel):
-    """Fake LLM wrapper for testing purposes."""
-
-    n: int = 1
-
-    def _generate(
-        self, prompts: List[str], stop: Optional[List[str]] = None
-    ) -> LLMResult:
-        return LLMResult(generations=[[Generation(text="foo") for _ in range(self.n)]])
-
-    @property
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-        return "fake"
 
 
 def test_hyde_from_llm() -> None:

--- a/tests/unit_tests/chains/test_llm.py
+++ b/tests/unit_tests/chains/test_llm.py
@@ -9,7 +9,7 @@ from langchain.chains.llm import LLMChain
 from langchain.chains.loading import load_chain
 from langchain.prompts.base import BaseOutputParser
 from langchain.prompts.prompt import PromptTemplate
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 class FakeOutputParser(BaseOutputParser):

--- a/tests/unit_tests/chains/test_llm_bash.py
+++ b/tests/unit_tests/chains/test_llm_bash.py
@@ -4,7 +4,7 @@ import pytest
 
 from langchain.chains.llm_bash.base import LLMBashChain
 from langchain.chains.llm_bash.prompt import _PROMPT_TEMPLATE
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 @pytest.fixture

--- a/tests/unit_tests/chains/test_llm_checker.py
+++ b/tests/unit_tests/chains/test_llm_checker.py
@@ -11,7 +11,7 @@ from langchain.chains.llm_checker.prompt import (
     _LIST_ASSERTIONS_TEMPLATE,
     _REVISED_ANSWER_TEMPLATE,
 )
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 @pytest.fixture

--- a/tests/unit_tests/chains/test_llm_math.py
+++ b/tests/unit_tests/chains/test_llm_math.py
@@ -4,7 +4,7 @@ import pytest
 
 from langchain.chains.llm_math.base import LLMMathChain
 from langchain.chains.llm_math.prompt import _PROMPT_TEMPLATE
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 @pytest.fixture

--- a/tests/unit_tests/chains/test_natbot.py
+++ b/tests/unit_tests/chains/test_natbot.py
@@ -6,27 +6,7 @@ from pydantic import BaseModel
 
 from langchain.chains.natbot.base import NatBotChain
 from langchain.llms.base import LLM
-
-
-# TODO: replace this with langchain/llms/fake_llm.py.
-class FakeLLM(LLM, BaseModel):
-    """Fake LLM wrapper for testing purposes."""
-
-    def _call(self, prompt: str, stop: Optional[List[str]] = None) -> str:
-        """Return `foo` if longer than 10000 words, else `bar`."""
-        if len(prompt) > 10000:
-            return "foo"
-        else:
-            return "bar"
-
-    @property
-    def _llm_type(self) -> str:
-        """Return type of llm."""
-        return "fake"
-
-    @property
-    def _identifying_params(self) -> Mapping[str, Any]:
-        return {}
+from langchain.llms.fake_llm import FakeLLM
 
 
 def test_proper_inputs() -> None:

--- a/tests/unit_tests/chains/test_natbot.py
+++ b/tests/unit_tests/chains/test_natbot.py
@@ -8,6 +8,7 @@ from langchain.chains.natbot.base import NatBotChain
 from langchain.llms.base import LLM
 
 
+# TODO: replace this with langchain/llms/fake_llm.py.
 class FakeLLM(LLM, BaseModel):
     """Fake LLM wrapper for testing purposes."""
 

--- a/tests/unit_tests/llms/test_base.py
+++ b/tests/unit_tests/llms/test_base.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import declarative_base
 import langchain
 from langchain.cache import InMemoryCache, SQLAlchemyCache
 from langchain.schema import Generation, LLMResult
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 def test_caching() -> None:

--- a/tests/unit_tests/llms/test_callbacks.py
+++ b/tests/unit_tests/llms/test_callbacks.py
@@ -1,7 +1,7 @@
 """Test LLM callbacks."""
 from langchain.callbacks.base import CallbackManager
 from tests.unit_tests.callbacks.fake_callback_handler import FakeCallbackHandler
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 def test_llm_with_callbacks() -> None:

--- a/tests/unit_tests/llms/test_loading.py
+++ b/tests/unit_tests/llms/test_loading.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from langchain.llms.loading import load_llm
-from tests.unit_tests.llms.fake_llm import FakeLLM
+from langchain.llms.fake_llm import FakeLLM
 
 
 @patch("langchain.llms.loading.type_to_cls_dict", {"fake": FakeLLM})


### PR DESCRIPTION
Make
 - `tests/unit_tests/chains/test_hyde.py`
 - `tests/unit_tests/chains/test_natbot.py`
 use it instead of defining their own.

### Risks
I changed the definition of `FakeLLM` to have a kind of union between the functionality in:
1. the original
2. the one in `tests/unit_tests/chains/test_hyde.py`
3. the one in `tests/unit_tests/chains/test_natbot.py`

But is this ok? Will all consumers of this class be ok with these changes?

### Testing and validation
 - The unit tests pass: `python3 -m pytest tests/unit_tests` for running unit tests in langchain`.
 - But integration tests: I can't run them. Current blocker there is a Google API key.

cc: @hwchase17